### PR TITLE
Gens II~VII Pokémon added to the game

### DIFF
--- a/assets/mantaro/texts/pokemonguess.txt
+++ b/assets/mantaro/texts/pokemonguess.txt
@@ -1,151 +1,907 @@
-http://oi40.tinypic.com/vdeh4p.jpg`Slowbro
-http://oi44.tinypic.com/15q3kgn.jpg`Metapod
-http://oi41.tinypic.com/zksb52.jpg`Zubat
-http://oi42.tinypic.com/rjfic7.jpg`Magneton
-http://oi42.tinypic.com/332p8pe.jpg`Beedrill
-http://oi44.tinypic.com/29uoz05.jpg`Omastar
-http://oi42.tinypic.com/153322f.jpg`Machamp
-http://oi40.tinypic.com/25jl91d.jpg`Electrode
-http://oi40.tinypic.com/fjlpwk.jpg`Wartortle
-http://oi40.tinypic.com/108i4uq.jpg`Venonat
-http://oi43.tinypic.com/2v12548.jpg`Persian
-http://oi41.tinypic.com/2yvklzr.jpg`Moltres
-http://oi41.tinypic.com/280jji1.jpg`Tentacool
-http://oi39.tinypic.com/10scfg3.jpg`Ekans
-http://oi41.tinypic.com/2zxw0sy.jpg`Chansey
-http://oi44.tinypic.com/2qv9k5h.jpg`Raticate
-http://oi39.tinypic.com/qoyjh0.jpg`Magikarp
-http://i.imgur.com/pMc81mO.jpg`Venusaur
-http://oi40.tinypic.com/2nbaukz.jpg`Flareon
-http://oi41.tinypic.com/zup2z5.jpg`Gengar
-http://oi40.tinypic.com/2e5pkzn.jpg`Jynx
-http://oi40.tinypic.com/2b9qgp.jpg`Snorlax
-http://oi43.tinypic.com/2vx3zm1.jpg`Pidgey
-http://oi41.tinypic.com/33nf7lc.jpg`Lickitung
-http://oi44.tinypic.com/307p9nb.jpg`Porygon
-http://oi41.tinypic.com/qs9qw5.jpg`Raichu
-http://oi43.tinypic.com/2r548qt.jpg`Clefable
-http://oi39.tinypic.com/14k9npt.jpg`Marowak
-http://oi44.tinypic.com/2s1ul48.jpg`Kabuto
-http://oi43.tinypic.com/2ljg4dl.jpg`Parasect
-http://oi41.tinypic.com/fe1729.jpg`Rhydon
-http://oi44.tinypic.com/2cpaufr.jpg`Meowth
-http://oi42.tinypic.com/14t7h9f.jpg`Dragonite
-http://oi44.tinypic.com/23t1spf.jpg`Blastoise
-http://oi40.tinypic.com/2vdgugm.jpg`Slowpoke
-http://oi44.tinypic.com/5pqtf7.jpg`Seel
-http://oi39.tinypic.com/33cupts.jpg`Wigglytuff
-http://oi40.tinypic.com/34znmfd.jpg`Charmander
-http://oi40.tinypic.com/29vfknd.jpg`Fearow
-http://oi42.tinypic.com/1z53p1x.jpg`Kadabra
-http://oi41.tinypic.com/148qdyu.jpg`Psyduck
-http://oi40.tinypic.com/2s7979l.jpg`Bellsprout
-http://oi42.tinypic.com/14udh8k.jpg`Omanyte
-http://oi43.tinypic.com/21dh8hv.jpg`Gastly
 http://oi41.tinypic.com/21o7nr9.jpg`Bulbasaur
-http://oi41.tinypic.com/1608uq8.jpg`Muk
-http://oi44.tinypic.com/2ecfyg4.jpg`Vileplume
-http://oi44.tinypic.com/20uo2s3.jpg`Poliwhirl
-http://oi39.tinypic.com/2zflb41.jpg`Magnemite
-http://oi41.tinypic.com/1q2xz9.jpg`Pidgeot
-http://oi39.tinypic.com/6nro84.jpg`Nidorina
-http://oi40.tinypic.com/2zel479.jpg`Articuno
-http://oi39.tinypic.com/15czi9y.jpg`Butterfree
-http://oi43.tinypic.com/21m7ou9.jpg`Graveler
-http://oi44.tinypic.com/mb74nn.jpg`Magmar
-http://oi40.tinypic.com/35i96pw.jpg`Arbok
-http://oi39.tinypic.com/ngo6fa.jpg`Cubone
-http://oi42.tinypic.com/2zzki90.jpg`Primeape
-http://oi39.tinypic.com/21j3x3p.jpg`Onix
-http://oi44.tinypic.com/34hbf51.jpg`Squirtle
-http://oi42.tinypic.com/3507xg0.jpg`Nidoran
-http://oi41.tinypic.com/ic0f12.jpg`Vulpix
-http://oi41.tinypic.com/244cqw0.jpg`Electabuzz
-http://oi42.tinypic.com/2rmtf1f.jpg`Cloyster
-http://oi41.tinypic.com/29olkyg.jpg`Growlithe
-http://oi41.tinypic.com/11t0nrc.jpg`Poliwag
-http://oi44.tinypic.com/29xvy3o.jpg`Horsea
-http://oi44.tinypic.com/2gsh2sg.jpg`Drowzee
-http://oi39.tinypic.com/21kzct3.jpg`Tentacruel
-http://oi42.tinypic.com/2n1rpzk.jpg`Voltorb
-http://oi42.tinypic.com/sg28ld.jpg`Victreebel
-http://oi43.tinypic.com/1zfkehg.jpg`Nidoqueen
-http://oi42.tinypic.com/2vlsnqe.jpg`Starmie
-http://oi43.tinypic.com/vi305t.jpg`Hitmonlee
-http://oi41.tinypic.com/m9na5l.jpg`Exeggcute
-http://oi41.tinypic.com/f44hhl.jpg`Venomoth
-http://oi44.tinypic.com/2i6gtxh.jpg`Dratini
-http://oi41.tinypic.com/119xq8l.jpg`Kakuna
-http://oi42.tinypic.com/vqu1ir.jpg`Dugtrio
-http://oi41.tinypic.com/x51g5l.jpg`Tauros
-http://oi39.tinypic.com/2wg7zpd.jpg`Dodrio
-http://oi42.tinypic.com/2z4h7jr.jpg`Arcanine
-http://oi44.tinypic.com/mw9r3a.jpg`Mr. Mime
-http://oi44.tinypic.com/21jp3eu.jpg`Sandslash
-http://oi44.tinypic.com/33u4t2d.jpg`Kangaskhan
-http://oi40.tinypic.com/2mh7ccm.jpg`Gyarados
-http://oi43.tinypic.com/95q7et.jpg`Kingler
-http://oi39.tinypic.com/2i0aeu0.jpg`Caterpie
-http://oi39.tinypic.com/10yncbn.jpg`Ninetales
-http://oi43.tinypic.com/n1uejr.jpg`Paras
-http://oi44.tinypic.com/2cdahdl.jpg`Machop
-http://i.imgur.com/7tOA2x1.jpg`Farfetch'd
-http://oi43.tinypic.com/nzkqjs.jpg`Rattata
-http://oi41.tinypic.com/a4r0k9.jpg`Jolteon
-http://oi43.tinypic.com/2rf7cba.jpg`Shellder
-http://oi41.tinypic.com/v5y39d.jpg`Golbat
-http://oi43.tinypic.com/2nisho6.jpg`Gloom
-http://oi41.tinypic.com/2uxv2ja.jpg`Mewtwo
-http://oi44.tinypic.com/2vtably.jpg`Pikachu
-http://oi44.tinypic.com/2cnf3i1.jpg`Seaking
-http://oi42.tinypic.com/2i8dh5s.jpg`Pinsir
-http://oi39.tinypic.com/2cbin5.jpg`Ditto
-http://oi40.tinypic.com/i36hb7.jpg`Koffing
-http://oi42.tinypic.com/b6qcec.jpg`Jigglypuff
-http://oi41.tinypic.com/15drnfl.jpg`Kabutops
-http://oi43.tinypic.com/2yphtmd.jpg`Abra
-http://oi42.tinypic.com/24pvv2o.jpg`Machoke
-http://oi41.tinypic.com/k2jyvo.jpg`Lapras
-http://oi39.tinypic.com/2ito5sw.jpg`Rhyhorn
-http://oi40.tinypic.com/30vklc9.jpg`Charmeleon
-http://oi42.tinypic.com/1scs5g.jpg`Mew
-http://oi44.tinypic.com/209hsmv.jpg`Geodude
-http://oi44.tinypic.com/50fdjs.jpg`Rapidash
-http://oi44.tinypic.com/sbhim0.jpg`Weepinbell
-http://oi44.tinypic.com/nmeyk7.jpg`Sandshrew
-http://oi42.tinypic.com/fdgbuq.jpg`Scyther
-http://oi44.tinypic.com/qpfn95.jpg`Seadra
-http://oi39.tinypic.com/14mbekj.jpg`Clefairy
-http://oi40.tinypic.com/ff26mv.jpg`Vaporeon
-http://oi41.tinypic.com/2upftvo.jpg`Nidoran
 http://oi41.tinypic.com/2gtymfs.jpg`Ivysaur
-http://oi41.tinypic.com/21biqkw.jpg`Staryu
-http://oi39.tinypic.com/ws8tis.jpg`Weezing
-http://oi41.tinypic.com/2zpt7q8.jpg`Krabby
-http://oi41.tinypic.com/s49u8h.jpg`Dragonair
-http://oi43.tinypic.com/296ocxg.jpg`Pidgeotto
-http://oi39.tinypic.com/2ebdfg5.jpg`Hitmonchan
-http://oi40.tinypic.com/vdhdh1.jpg`Eevee
-http://oi39.tinypic.com/2lua0qv.jpg`Mankey
-http://oi41.tinypic.com/6jmv0g.jpg`Grimer
-http://oi41.tinypic.com/avl850.jpg`Spearow
-http://oi42.tinypic.com/309sv4l.jpg`Zapdos
+http://i.imgur.com/pMc81mO.jpg`Venusaur
+http://oi40.tinypic.com/34znmfd.jpg`Charmander
+http://oi40.tinypic.com/30vklc9.jpg`Charmeleon
 http://oi41.tinypic.com/20foxso.jpg`Charizard
-http://oi42.tinypic.com/33bpctj.jpg`Doduo
-http://oi44.tinypic.com/70yxb7.jpg`Oddish
-http://oi40.tinypic.com/nwyply.jpg`Diglett
-http://oi42.tinypic.com/28bb0go.jpg`Dewgong
-http://oi39.tinypic.com/2r54xhw.jpg`Nidoking
-http://oi43.tinypic.com/xoiqea.jpg`Exeggutor
-http://oi42.tinypic.com/r0e5o6.jpg`Ponyta
+http://i.imgur.com/QvXoZHQ.jpg`Mega Charizard X
+http://i.imgur.com/SAQgO9H.jpg`Mega Charizard Y
+http://i.imgur.com/QtoW2Kv.jpgw`Mega Venusaur
+http://oi44.tinypic.com/34hbf51.jpg`Squirtle
+http://oi40.tinypic.com/fjlpwk.jpg`Wartortle
+http://oi44.tinypic.com/23t1spf.jpg`Blastoise
+http://i.imgur.com/7AcBerG.jpg`Mega Blastoise
+http://oi39.tinypic.com/2i0aeu0.jpg`Caterpie
+http://oi44.tinypic.com/15q3kgn.jpg`Metapod
+http://oi39.tinypic.com/15czi9y.jpg`Butterfree
 http://oi43.tinypic.com/15dwiva.jpg`Weedle
-http://oi40.tinypic.com/2m4xfn4.jpg`Alakazam
-http://oi44.tinypic.com/2qizs5j.jpg`Hypno
-http://oi40.tinypic.com/11114zk.jpg`Haunter
+http://oi41.tinypic.com/119xq8l.jpg`Kakuna
+http://oi42.tinypic.com/332p8pe.jpg`Beedrill
+http://i.imgur.com/rmw7sWt.jpg`Mega Beedrill
+http://oi43.tinypic.com/2vx3zm1.jpg`Pidgey
+http://oi43.tinypic.com/296ocxg.jpg`Pidgeotto
+http://oi41.tinypic.com/1q2xz9.jpg`Pidgeot
+http://i.imgur.com/Kke3dkS.jpg`Mega Pidgeot
+http://oi43.tinypic.com/nzkqjs.jpg`Rattata
+http://i.imgur.com/f6v7h5E.jpg`Alolan Rattata
+http://oi44.tinypic.com/2qv9k5h.jpg`Raticate
+http://i.imgur.com/QASVL0Q.jpg`Alolan Raticate
+http://oi41.tinypic.com/avl850.jpg`Spearow
+http://oi40.tinypic.com/29vfknd.jpg`Fearow
+http://oi39.tinypic.com/10scfg3.jpg`Ekans
+http://oi40.tinypic.com/35i96pw.jpg`Arbok
+http://oi44.tinypic.com/2vtably.jpg`Pikachu
+http://oi41.tinypic.com/qs9qw5.jpg`Raichu
+http://i.imgur.com/7tsczcG.jpg`Alolan Raichu
+http://oi44.tinypic.com/nmeyk7.jpg`Sandshrew
+http://i.imgur.com/BshGK6t.jpg`Alolan Sandshrew
+http://oi44.tinypic.com/21jp3eu.jpg`Sandslash
+http://i.imgur.com/fZpTntd.jpg`Alolan Sandslash
+http://oi42.tinypic.com/3507xg0.jpg`Nidoran
+http://oi39.tinypic.com/6nro84.jpg`Nidorina
+http://oi43.tinypic.com/1zfkehg.jpg`Nidoqueen
+http://oi41.tinypic.com/2upftvo.jpg`Nidoran
 http://oi39.tinypic.com/2hictnm.jpg`Nidorino
-http://oi41.tinypic.com/ajxvdu.jpg`Goldeen
-http://oi43.tinypic.com/15z1l4m.jpg`Golem
-http://oi43.tinypic.com/2qlhd1e.jpg`Poliwrath
-http://oi41.tinypic.com/28kpvkw.jpg`Aerodactyl
-http://oi42.tinypic.com/ta34e9.jpg`Tangela
+http://oi39.tinypic.com/2r54xhw.jpg`Nidoking
+http://oi39.tinypic.com/14mbekj.jpg`Clefairy
+http://oi43.tinypic.com/2r548qt.jpg`Clefable
+http://oi41.tinypic.com/ic0f12.jpg`Vulpix
+http://i.imgur.com/a9q2BsU.jpg`Alolan Vulpix
+http://oi39.tinypic.com/10yncbn.jpg`Ninetales
+http://i.imgur.com/36fxcXa.jpg`Alolan Ninetales
+http://oi42.tinypic.com/b6qcec.jpg`Jigglypuff
+http://oi39.tinypic.com/33cupts.jpg`Wigglytuff
+http://oi41.tinypic.com/zksb52.jpg`Zubat
+http://oi41.tinypic.com/v5y39d.jpg`Golbat
+http://oi44.tinypic.com/70yxb7.jpg`Oddish
+http://oi43.tinypic.com/2nisho6.jpg`Gloom
+http://oi44.tinypic.com/2ecfyg4.jpg`Vileplume
+http://oi43.tinypic.com/n1uejr.jpg`Paras
+http://oi43.tinypic.com/2ljg4dl.jpg`Parasect
+http://oi40.tinypic.com/108i4uq.jpg`Venonat
+http://oi41.tinypic.com/f44hhl.jpg`Venomoth
+http://oi40.tinypic.com/nwyply.jpg`Diglett
+http://i.imgur.com/rxAc1rx.jpg`Alolan Diglett
+http://oi42.tinypic.com/vqu1ir.jpg`Dugtrio
+http://i.imgur.com/ZuFa9A5.jpg`Alolan Dugtrio
+http://oi44.tinypic.com/2cpaufr.jpg`Meowth
+http://i.imgur.com/IEJxgi4.jpg`Alolan Meowth
+http://oi43.tinypic.com/2v12548.jpg`Persian
+http://i.imgur.com/dEHadLv.jpg`Alolan Persian
+http://oi41.tinypic.com/148qdyu.jpg`Psyduck
 http://oi39.tinypic.com/2qt97om.jpg`Golduck
+http://oi39.tinypic.com/2lua0qv.jpg`Mankey
+http://oi42.tinypic.com/2zzki90.jpg`Primeape
+http://oi41.tinypic.com/29olkyg.jpg`Growlithe
+http://oi42.tinypic.com/2z4h7jr.jpg`Arcanine
+http://oi41.tinypic.com/11t0nrc.jpg`Poliwag
+http://oi44.tinypic.com/20uo2s3.jpg`Poliwhirl
+http://oi43.tinypic.com/2qlhd1e.jpg`Poliwrath
+http://oi43.tinypic.com/2yphtmd.jpg`Abra
+http://oi42.tinypic.com/1z53p1x.jpg`Kadabra
+http://oi40.tinypic.com/2m4xfn4.jpg`Alakazam
+http://i.imgur.com/xPI8CSb.jpg`Mega Alakazam
+http://oi44.tinypic.com/2cdahdl.jpg`Machop
+http://oi42.tinypic.com/24pvv2o.jpg`Machoke
+http://oi42.tinypic.com/153322f.jpg`Machamp
+http://oi40.tinypic.com/2s7979l.jpg`Bellsprout
+http://oi44.tinypic.com/sbhim0.jpg`Weepinbell
+http://oi42.tinypic.com/sg28ld.jpg`Victreebel
+http://oi41.tinypic.com/280jji1.jpg`Tentacool
+http://oi39.tinypic.com/21kzct3.jpg`Tentacruel
+http://oi44.tinypic.com/209hsmv.jpg`Geodude
+http://i.imgur.com/M3jCx4l.jpg`Alolan Geodude
+http://oi43.tinypic.com/21m7ou9.jpg`Graveler
+http://i.imgur.com/oiWrK3R.jpg`Alolan Graveler
+http://oi43.tinypic.com/15z1l4m.jpg`Golem
+http://i.imgur.com/CYsvgGN.jpg`Alolan Golem
+http://oi42.tinypic.com/r0e5o6.jpg`Ponyta
+http://oi44.tinypic.com/50fdjs.jpg`Rapidash
+http://oi40.tinypic.com/2vdgugm.jpg`Slowpoke
+http://oi40.tinypic.com/vdeh4p.jpg`Slowbro
+http://i.imgur.com/1Kp5ghV.jpg`Mega Slowbro
+http://oi39.tinypic.com/2zflb41.jpg`Magnemite
+http://oi42.tinypic.com/rjfic7.jpg`Magneton
+http://i.imgur.com/7tOA2x1.jpg`Farfetch'd
+http://oi42.tinypic.com/33bpctj.jpg`Doduo
+http://oi39.tinypic.com/2wg7zpd.jpg`Dodrio
+http://oi44.tinypic.com/5pqtf7.jpg`Seel
+http://oi42.tinypic.com/28bb0go.jpg`Dewgong
+http://oi41.tinypic.com/6jmv0g.jpg`Grimer
+http://i.imgur.com/jT9VBcS.jpg`Alolan Grimer
+http://oi41.tinypic.com/1608uq8.jpg`Muk
+http://i.imgur.com/ZsILJau.jpg`Alolan Muk
+http://oi43.tinypic.com/2rf7cba.jpg`Shellder
+http://oi42.tinypic.com/2rmtf1f.jpg`Cloyster
+http://oi43.tinypic.com/21dh8hv.jpg`Gastly
+http://oi40.tinypic.com/11114zk.jpg`Haunter
+http://oi41.tinypic.com/zup2z5.jpg`Gengar
+http://i.imgur.com/yifA79W.jpg`Mega Gengar
+http://oi39.tinypic.com/21j3x3p.jpg`Onix
+http://oi44.tinypic.com/2gsh2sg.jpg`Drowzee
+http://oi44.tinypic.com/2qizs5j.jpg`Hypno
+http://oi41.tinypic.com/2zpt7q8.jpg`Krabby
+http://oi43.tinypic.com/95q7et.jpg`Kingler
+http://oi42.tinypic.com/2n1rpzk.jpg`Voltorb
+http://oi40.tinypic.com/25jl91d.jpg`Electrode
+http://oi41.tinypic.com/m9na5l.jpg`Exeggcute
+http://oi43.tinypic.com/xoiqea.jpg`Exeggutor
+http://i.imgur.com/qh0LLiU.jpg`Alolan Exeggutor
+http://oi39.tinypic.com/ngo6fa.jpg`Cubone
+http://oi39.tinypic.com/14k9npt.jpg`Marowak
+http://i.imgur.com/V5dg5a4.jpg`Alolan Marowak
+http://oi43.tinypic.com/vi305t.jpg`Hitmonlee
+http://oi39.tinypic.com/2ebdfg5.jpg`Hitmonchan
+http://oi41.tinypic.com/33nf7lc.jpg`Lickitung
+http://oi40.tinypic.com/i36hb7.jpg`Koffing
+http://oi39.tinypic.com/ws8tis.jpg`Weezing
+http://oi39.tinypic.com/2ito5sw.jpg`Rhyhorn
+http://oi41.tinypic.com/fe1729.jpg`Rhydon
+http://oi41.tinypic.com/2zxw0sy.jpg`Chansey
+http://oi42.tinypic.com/ta34e9.jpg`Tangela
+http://oi44.tinypic.com/33u4t2d.jpg`Kangaskhan
+http://i.imgur.com/V95Fp8m.jpg`Mega Kangaskhan
+http://oi44.tinypic.com/29xvy3o.jpg`Horsea
+http://oi44.tinypic.com/qpfn95.jpg`Seadra
+http://oi41.tinypic.com/ajxvdu.jpg`Goldeen
+http://oi44.tinypic.com/2cnf3i1.jpg`Seaking
+http://oi41.tinypic.com/21biqkw.jpg`Staryu
+http://oi42.tinypic.com/2vlsnqe.jpg`Starmie
+http://oi44.tinypic.com/mw9r3a.jpg`Mr. Mime
+http://oi42.tinypic.com/fdgbuq.jpg`Scyther
+http://oi40.tinypic.com/2e5pkzn.jpg`Jynx
+http://oi41.tinypic.com/244cqw0.jpg`Electabuzz
+http://oi44.tinypic.com/mb74nn.jpg`Magmar
+http://oi42.tinypic.com/2i8dh5s.jpg`Pinsir
+http://i.imgur.com/ve1NKtL.jpg`Mega Pinsir
+http://oi41.tinypic.com/x51g5l.jpg`Tauros
+http://oi39.tinypic.com/qoyjh0.jpg`Magikarp
+http://oi40.tinypic.com/2mh7ccm.jpg`Gyarados
+http://i.imgur.com/A70nMsz.jpg`Mega Gyarados
+http://oi41.tinypic.com/k2jyvo.jpg`Lapras
+http://oi39.tinypic.com/2cbin5.jpg`Ditto
+http://oi40.tinypic.com/vdhdh1.jpg`Eevee
+http://oi40.tinypic.com/ff26mv.jpg`Vaporeon
+http://oi41.tinypic.com/a4r0k9.jpg`Jolteon
+http://oi40.tinypic.com/2nbaukz.jpg`Flareon
+http://oi44.tinypic.com/307p9nb.jpg`Porygon
+http://oi42.tinypic.com/14udh8k.jpg`Omanyte
+http://oi44.tinypic.com/29uoz05.jpg`Omastar
+http://oi44.tinypic.com/2s1ul48.jpg`Kabuto
+http://oi41.tinypic.com/15drnfl.jpg`Kabutops
+http://oi41.tinypic.com/28kpvkw.jpg`Aerodactyl
+http://i.imgur.com/88U6NBc.jpg`Mega Aerodactyl
+http://oi40.tinypic.com/2b9qgp.jpg`Snorlax
+http://oi40.tinypic.com/2zel479.jpg`Articuno
+http://oi42.tinypic.com/309sv4l.jpg`Zapdos
+http://oi41.tinypic.com/2yvklzr.jpg`Moltres
+http://oi44.tinypic.com/2i6gtxh.jpg`Dratini
+http://oi41.tinypic.com/s49u8h.jpg`Dragonair
+http://oi42.tinypic.com/14t7h9f.jpg`Dragonite
+http://oi41.tinypic.com/2uxv2ja.jpg`Mewtwo
+http://i.imgur.com/DZrQqaC.jpg`Mega Mewtwo X
+http://i.imgur.com/6vUcqZJ.jpg`Mega Mewtwo Y
+http://oi42.tinypic.com/1scs5g.jpg`Mew
+http://i.imgur.com/5CkMHRQ.png`Chikorita
+http://i.imgur.com/bjuOLfL.png`Bayleef
+http://i.imgur.com/z0LsjhF.png`Meganium
+http://i.imgur.com/GJIPRMf.png`Cyndaquil
+http://i.imgur.com/X88SQJD.png`Quilava
+http://i.imgur.com/R2Qh49c.png`Typhlosion
+http://i.imgur.com/0qELfX6.png`Totodile
+http://i.imgur.com/2c6M8kh.png`Croconaw
+http://i.imgur.com/4Ky37Ap.png`Feraligatr
+http://i.imgur.com/O33o1aT.png`Sentret
+http://i.imgur.com/x7pIcxJ.png`Furret
+http://i.imgur.com/pZdgaYH.png`Hoothoot
+http://i.imgur.com/7ficBT1.png`Noctowl
+http://i.imgur.com/9ZAwvcj.png`Ledyba
+http://i.imgur.com/tr018SD.png`Ledian
+http://i.imgur.com/g1umrCF.png`Spinarak
+http://i.imgur.com/T3jljFR.png`Ariados
+http://i.imgur.com/5cpL1Lx.png`Crobat
+http://i.imgur.com/P2gpPfe.png`Chinchou
+http://i.imgur.com/hIJVekS.png`Lanturn
+http://i.imgur.com/sylO4Qs.png`Pichu
+http://i.imgur.com/rsi8ElF.png`Cleffa
+http://i.imgur.com/IaJGg0i.png`Igglybuff
+http://i.imgur.com/lDIe5ps.png`Togepi
+http://i.imgur.com/7zN20x8.png`Togetic
+http://i.imgur.com/LVuLnOE.png`Natu
+http://i.imgur.com/bW2Rd5M.png`Xatu
+http://i.imgur.com/eYrdORl.png`Mareep
+http://i.imgur.com/fUm98mP.png`Flaaffy
+http://i.imgur.com/LPEkXmJ.png`Ampharos
+http://i.imgur.com/r68IlP6.jpg`Mega Ampharos
+http://i.imgur.com/TklGaMh.png`Bellossom
+http://i.imgur.com/OkpRr5a.png`Marill
+http://i.imgur.com/qjxXGLJ.png`Azumarill
+http://i.imgur.com/HQ4PzSq.png`Sudowoodo
+http://i.imgur.com/W6gT4RW.png`Politoed
+http://i.imgur.com/PvFhj11.png`Hoppip
+http://i.imgur.com/nIcSf64.png`Skiploom
+http://i.imgur.com/yfw6EY6.png`Jumpluff
+http://i.imgur.com/sjjogZL.png`Aipom
+http://i.imgur.com/SzKTXpd.png`Sunkern
+http://i.imgur.com/tRdqyui.png`Sunflora
+http://i.imgur.com/MmiokjK.png`Yanma
+http://i.imgur.com/vODKQAn.png`Wooper
+http://i.imgur.com/uq4ixtz.png`Quagsire
+http://i.imgur.com/anI3Rn9.png`Espeon
+http://i.imgur.com/UswgRF7.png`Umbreon
+http://i.imgur.com/mFVgAFH.png`Murkrow
+http://i.imgur.com/240K5Oe.png`Slowking
+http://i.imgur.com/2iPuprG.png`Misdreavus
+http://i.imgur.com/myqpcWb.png`Unown
+http://i.imgur.com/GrsZv7n.png`Wobbuffet
+http://i.imgur.com/ywJga2M.png`Girafarig
+http://i.imgur.com/nBr56Ya.png`Pineco
+http://i.imgur.com/pbXX6Fb.png`Forretress
+http://i.imgur.com/eXBGerz.png`Dunsparce
+http://i.imgur.com/ZN26xfc.png`Gligar
+http://i.imgur.com/xxbI6ZG.png`Steelix
+http://i.imgur.com/qJ0fFPG.jpg`Mega Steelix
+http://i.imgur.com/LTmmQGF.png`Snubbull
+http://i.imgur.com/TiY7rPk.png`Granbull
+http://i.imgur.com/zSDi8R9.png`Qwilfish
+http://i.imgur.com/Lg0MsYZ.png`Scizor
+http://i.imgur.com/qyjgPLl.jpg`Mega Scizor
+http://i.imgur.com/I1nz3Zq.png`Shuckle
+http://i.imgur.com/fzF4vrD.png`Heracross
+http://i.imgur.com/2cQtWSi.jpg`Mega Heracross
+http://i.imgur.com/veSAhJ9.png`Sneasel
+http://i.imgur.com/g2hxiw5.png`Teddiursa
+http://i.imgur.com/WiztXEf.png`Ursaring
+http://i.imgur.com/BD8fBzL.png`Slugma
+http://i.imgur.com/xzWxA8p.png`Magcargo
+http://i.imgur.com/5a7Dnmo.png`Swinub
+http://i.imgur.com/ETpowSj.png`Piloswine
+http://i.imgur.com/xeDwLbf.png`Corsola
+http://i.imgur.com/YJY4ZPV.png`Remoraid
+http://i.imgur.com/NSf83ob.png`Octillery
+http://i.imgur.com/86hpgPr.png`Delibird
+http://i.imgur.com/p85fgqJ.png`Mantine
+http://i.imgur.com/Cs8R8jz.png`Skarmory
+http://i.imgur.com/MrmppRT.png`Houndour
+http://i.imgur.com/P8OP6ps.png`Houndoom
+http://i.imgur.com/Z44ccgF.jpg`Mega Houndoom
+http://i.imgur.com/e2jOa8B.png`Kingdra
+http://i.imgur.com/3Ct925E.png`Phanpy
+http://i.imgur.com/LLUlA2V.png`Donphan
+http://i.imgur.com/U6lNFQH.png`Porygon2
+http://i.imgur.com/rnQlVC8.png`Stantler
+http://i.imgur.com/GvAuzBx.png`Smeargle
+http://i.imgur.com/zf75ybb.png`Tyrogue
+http://i.imgur.com/A7Lw7qU.png`Hitmontop
+http://i.imgur.com/Y5kSx9m.png`Smoochum
+http://i.imgur.com/3Meq3Ka.png`Elekid
+http://i.imgur.com/LeG9Xc2.png`Magby
+http://i.imgur.com/Wbb9nkn.png`Miltank
+http://i.imgur.com/YAWwF41.png`Blissey
+http://i.imgur.com/tRQKwj7.png`Raikou
+http://i.imgur.com/J4arYsP.png`Entei
+http://i.imgur.com/eDbVKha.png`Suicune
+http://i.imgur.com/gtI2GBu.png`Larvitar
+http://i.imgur.com/Hwc2cb5.png`Pupitar
+http://i.imgur.com/dBBfv1E.png`Tyranitar
+http://i.imgur.com/aWqdtWp.jpg`Mega Tyranitar
+http://i.imgur.com/fgEdb4y.png`Lugia
+http://i.imgur.com/gPo1h7P.png`Ho-Oh
+http://i.imgur.com/Lc0rPfO.png`Celebi
+http://i.imgur.com/a59hcKW.jpg`Treecko
+http://i.imgur.com/kDAZfU1.jpg`Grovyle
+http://i.imgur.com/ad5sQvb.jpg`Sceptile
+http://i.imgur.com/L4q8BFH.jpg`Mega Sceptile
+http://i.imgur.com/zErns3z.jpg`Torchic
+http://i.imgur.com/8IkZvS5.jpg`Combusken
+http://i.imgur.com/6NAfaS1.jpg`Blaziken
+http://i.imgur.com/EHgnzwM.jpg`Mega Blaziken
+http://i.imgur.com/U2920s6.jpg`Mudkip
+http://i.imgur.com/CDU8DbH.jpg`Marshtomp
+http://i.imgur.com/NpOXECn.jpg`Swampert
+http://i.imgur.com/BjWGdab.jpg`Mega Swampert
+http://i.imgur.com/4P8190t.jpg`Poochyena
+http://i.imgur.com/TuibhzT.jpg`Mightyena
+http://i.imgur.com/Zs1SSo2.jpg`Zigzagoon
+http://i.imgur.com/DFWPdcI.jpg`Linoone
+http://i.imgur.com/Uvk5r0U.jpg`Wurmple
+http://i.imgur.com/UXBgc0n.jpg`Silcoon
+http://i.imgur.com/GI7nmFq.jpg`Beautifly
+http://i.imgur.com/QXTXIYm.jpg`Cascoon
+http://i.imgur.com/ouHmu1m.jpg`Dustox
+http://i.imgur.com/7VovSKC.jpg`Lotad
+http://i.imgur.com/e6LjbNl.jpg`Lombre
+http://i.imgur.com/avLhkMJ.jpg`Ludicolo
+http://i.imgur.com/ORHmYB6.jpg`Seedot
+http://i.imgur.com/qS0CNzl.jpg`Nuzleaf
+http://i.imgur.com/Sn2FNJJ.jpg`Shiftry
+http://i.imgur.com/inBI4KQ.jpg`Taillow
+http://i.imgur.com/gyg77xx.jpg`Swellow
+http://i.imgur.com/LgSSsue.jpg`Wingull
+http://i.imgur.com/jcQ6ii0.jpg`Pelipper
+http://i.imgur.com/7X5VF0P.jpg`Ralts
+http://i.imgur.com/aqTEelt.jpg`Kirlia
+http://i.imgur.com/CfKyL43.jpg`Gardevoir
+http://i.imgur.com/7uC6Le7.jpg`Mega Gardevoir
+http://i.imgur.com/tdGEgeV.jpg`Surskit
+http://i.imgur.com/jAaoEPT.jpg`Masquerain
+http://i.imgur.com/qLZMwQV.jpg`Shroomish
+http://i.imgur.com/JhTQziQ.jpg`Breloom
+http://i.imgur.com/gReSBma.jpg`Slakoth
+http://i.imgur.com/sdBEZuy.jpg`Vigoroth
+http://i.imgur.com/x9vj979.jpg`Slaking
+http://i.imgur.com/XUvDT5H.jpg`Nincada
+http://i.imgur.com/BOrKbKl.jpg`Ninjask
+http://i.imgur.com/tXgl0GF.jpg`Shedinja
+http://i.imgur.com/eG4A0Mw.jpg`Whismur
+http://i.imgur.com/Zvj3ysq.jpg`Loudred
+http://i.imgur.com/N07jplB.jpg`Exploud
+http://i.imgur.com/aAKHEeR.jpg`Makuhita
+http://i.imgur.com/zdUcJau.jpg`Hariyama
+http://i.imgur.com/kR8gunK.jpg`Azurill
+http://i.imgur.com/afnXcPW.jpg`Nosepass
+http://i.imgur.com/UCtBies.jpg`Skitty
+http://i.imgur.com/q9KW0ED.jpg`Delcatty
+http://i.imgur.com/VRLGTNy.jpg`Sableye
+http://i.imgur.com/DUQxfQY.jpg`Mega Sableye
+http://i.imgur.com/1f3Mjhx.jpg`Mawile
+http://i.imgur.com/vexldZA.jpg`Mega Mawile
+http://i.imgur.com/KYNRade.jpg`Aron
+http://i.imgur.com/MdFlaIy.jpg`Lairon
+http://i.imgur.com/bdEZNQX.jpg`Aggron
+http://i.imgur.com/YjRGHOk.jpg`Mega Aggron
+http://i.imgur.com/5BQW028.jpg`Meditite
+http://i.imgur.com/wodxow0.jpg`Medicham
+http://i.imgur.com/Fx4DpT6.jpg`Mega Medicham
+http://i.imgur.com/izcXzaE.jpg`Electrike
+http://i.imgur.com/eh3EWS5.jpg`Manectric
+http://i.imgur.com/GZ1gJgV.jpg`Mega Manectric
+http://i.imgur.com/EviLR9k.jpg`Plusle
+http://i.imgur.com/5j7aCN7.jpg`Minun
+http://i.imgur.com/6KvumHj.jpg`Volbeat
+http://i.imgur.com/je1OhZV.jpg`Illumise
+http://i.imgur.com/OUFEnxd.jpg`Roselia
+http://i.imgur.com/HQj6wMe.jpg`Gulpin
+http://i.imgur.com/oiJ8Ohd.jpg`Swalot
+http://i.imgur.com/cVwxRai.jpg`Carvanha
+http://i.imgur.com/W2dHzD4.jpg`Sharpedo
+http://i.imgur.com/1Km6fZl.jpg`Mega Sharpedo
+http://i.imgur.com/pVpnVbP.jpg`Wailmer
+http://i.imgur.com/CMWHME6.jpg`Wailord
+http://i.imgur.com/A1NOIJA.jpg`Numel
+http://i.imgur.com/yjv2Koy.jpg`Camerupt
+http://i.imgur.com/1mmxYQg.jpg`Mega Camerupt
+http://i.imgur.com/A21pTso.jpg`Torkoal
+http://i.imgur.com/nmcvR8P.jpg`Spoink
+http://i.imgur.com/i6DFMxI.jpg`Grumpig
+http://i.imgur.com/FtqazT5.jpg`Spinda
+http://i.imgur.com/8kDZ1Kl.jpg`Trapinch
+http://i.imgur.com/HAEEV8w.jpg`Vibrava
+http://i.imgur.com/Pdze3G4.jpg`Flygon
+http://i.imgur.com/K1rp9ln.jpg`Cacnea
+http://i.imgur.com/gan9zWy.jpg`Cacturne
+http://i.imgur.com/6Tx9lLO.jpg`Swablu
+http://i.imgur.com/4ejf60x.jpg`Altaria
+http://i.imgur.com/IPbGjhR.jpg`Mega Altaria
+http://i.imgur.com/bptg0yK.jpg`Zangoose
+http://i.imgur.com/Lb8HoQe.jpg`Seviper
+http://i.imgur.com/SpCt5Tq.jpg`Lunatone
+http://i.imgur.com/6GB01h0.jpg`Solrock
+http://i.imgur.com/VGHtUEW.jpg`Barboach
+http://i.imgur.com/n3SGCY9.jpg`Whiscash
+http://i.imgur.com/YkdBJ9i.jpg`Corphish
+http://i.imgur.com/ZmsIb6f.jpg`Crawdaunt
+http://i.imgur.com/YaNCtzB.jpg`Baltoy
+http://i.imgur.com/kKVAzwZ.jpg`Claydol
+http://i.imgur.com/xoqYpKn.jpg`Lileep
+http://i.imgur.com/6l9D6GZ.jpg`Cradily
+http://i.imgur.com/0CkiSWY.jpg`Anorith
+http://i.imgur.com/Jk6gkko.jpg`Armaldo
+http://i.imgur.com/KlizK5G.jpg`Feebas
+http://i.imgur.com/TXA83AE.jpg`Milotic
+http://i.imgur.com/IsMEasj.jpg`Castform
+http://i.imgur.com/b9E2MAT.jpg`Kecleon
+http://i.imgur.com/FiFIxhv.jpg`Shuppet
+http://i.imgur.com/Rc96g20.jpg`Banette
+http://i.imgur.com/1J13ngw.jpg`Mega Banette
+http://i.imgur.com/9xcRgdg.jpg`Duskull
+http://i.imgur.com/zBBvlDq.jpg`Dusclops
+http://i.imgur.com/IrHA0ha.jpg`Tropius
+http://i.imgur.com/XB7Yn7U.jpg`Chimecho
+http://i.imgur.com/7oofAaV.jpg`Absol
+http://i.imgur.com/uKwHQGq.jpg`Wynaut
+http://i.imgur.com/JT9VB4U.jpg`Snorunt
+http://i.imgur.com/xmdcLM5.jpg`Glalie
+http://i.imgur.com/Gtvyui0.jpg`Mega Glalie
+http://i.imgur.com/hLA3lEW.jpg`Spheal
+http://i.imgur.com/Ij0QicK.jpg`Sealeo
+http://i.imgur.com/UKOnxD6.jpg`Walrein
+http://i.imgur.com/8S1iocm.jpg`Clamperl
+http://i.imgur.com/xXXUKBU.jpg`Huntail
+http://i.imgur.com/bUIhjFd.jpg`Gorebyss
+http://i.imgur.com/LNwJTgW.jpg`Relicanth
+http://i.imgur.com/9fRAMGg.jpg`Luvdisc
+http://i.imgur.com/fh6j77L.jpg`Bagon
+http://i.imgur.com/yn62xMD.jpg`Shelgon
+http://i.imgur.com/43D35io.jpg`Salamence
+http://i.imgur.com/VH1nSBY.jpg`Mega Salamence
+http://i.imgur.com/ZofxVEw.jpg`Beldum
+http://i.imgur.com/dhJzOTY.jpg`Metang
+http://i.imgur.com/Pr1ErKv.jpg`Metagross
+http://i.imgur.com/bpAwlSU.jpg`Mega Metagross
+http://i.imgur.com/Bq1OVvE.jpg`Regirock
+http://i.imgur.com/1UwaqlV.jpg`Regice
+http://i.imgur.com/sWUpZAC.jpg`Registeel
+http://i.imgur.com/WQr2LSo.jpg`Latias
+http://i.imgur.com/eDwzlX3.jpg`Mega Latias
+http://i.imgur.com/pYOyxqb.jpg`Latios
+http://i.imgur.com/RBEJPtS.jpg`Mega Latios
+http://i.imgur.com/JKND3qY.jpg`Kyogre
+http://i.imgur.com/YZYItAa.jpg`Primal Kyogre
+http://i.imgur.com/PbmYqIu.jpg`Groudon
+http://i.imgur.com/tOn7Dxb.jpg`Primal Groudon
+http://i.imgur.com/vGQPGC8.jpg`Rayquaza
+http://i.imgur.com/SYp0wZG.jpg`Mega Rayquaza
+http://i.imgur.com/trN2yZO.jpg`Jirachi
+http://i.imgur.com/SgVEPev.jpg`Deoxys
+http://i.imgur.com/NcaBblR.jpg`Deoxys Attack
+http://i.imgur.com/FzySsTv.jpg`Deoxys Defense
+http://i.imgur.com/XNHC4Ey.jpg`Deoxys Speed
+http://i.imgur.com/JrjugDw.jpg`Turtwig
+http://i.imgur.com/UOwni3h.jpg`Grotle
+http://i.imgur.com/WsxCr6G.jpg`Torterra
+http://i.imgur.com/Wxfvw8I.jpg`Chimchar
+http://i.imgur.com/2VSwBxY.jpg`Monferno
+http://i.imgur.com/37awZik.jpg`Infernape
+http://i.imgur.com/cxYIN6D.jpg`Piplup
+http://i.imgur.com/OLekaI4.jpg`Prinplup
+http://i.imgur.com/JOHVavw.jpg`Empoleon
+http://i.imgur.com/oxU8XlA.jpg`Starly
+http://i.imgur.com/DXUwo68.jpg`Staravia
+http://i.imgur.com/acD0t4G.jpg`Staraptor
+http://i.imgur.com/VbFzNH1.jpg`Bidoof
+http://i.imgur.com/Hcq8CyL.jpg`Bibarel
+http://i.imgur.com/fuKXf9H.jpg`Kricketot
+http://i.imgur.com/Q1HEPIo.jpg`Kricketune
+http://i.imgur.com/uWfHVKj.jpg`Shinx
+http://i.imgur.com/92FZtKP.jpg`Luxio
+http://i.imgur.com/D4myiWV.jpg`Luxray
+http://i.imgur.com/FXbkNPz.jpg`Budew
+http://i.imgur.com/Tt8gojx.jpg`Roserade
+http://i.imgur.com/RoZRpkc.jpg`Cranidos
+http://i.imgur.com/Vc12mf8.jpg`Rampardos
+http://i.imgur.com/YYcoGmp.jpg`Shieldon
+http://i.imgur.com/mP2nZsb.jpg`Bastiodon
+http://i.imgur.com/8v6X5kO.jpg`Burmy
+http://i.imgur.com/vKBCWxk.jpg`Burmy
+http://i.imgur.com/XxWANAp.jpg`Burmy
+http://i.imgur.com/DWznqnL.jpg`Wormadam
+http://i.imgur.com/v6zAZdF.jpg`Wormadam
+http://i.imgur.com/uwlMGLa.jpg`Wormadam
+http://i.imgur.com/yHKoWNw.jpg`Mothim
+http://i.imgur.com/dMfigRf.jpg`Combee
+http://i.imgur.com/wfwqwaC.jpg`Vespiquen
+http://i.imgur.com/rmdn9jK.jpg`Pachirisu
+http://i.imgur.com/bV9eP1L.jpg`Buizel
+http://i.imgur.com/eg3AcnA.jpg`Floatzel
+http://i.imgur.com/6e0FArR.jpg`Cherubi
+http://i.imgur.com/itA0itc.jpg`Cherrim
+http://i.imgur.com/w1gUz7s.jpg`Cherrim
+http://i.imgur.com/AXM5V1v.jpg`Shellos
+http://i.imgur.com/Co7o1VJ.jpg`Shellos
+http://i.imgur.com/LMXw5E4.jpg`Gastrodon
+http://i.imgur.com/deUpZmh.jpg`Gastrodon
+http://i.imgur.com/qyBxDHB.jpg`Ambipom
+http://i.imgur.com/Kmi3WyR.jpg`Drifloon
+http://i.imgur.com/0TIxgao.jpg`Drifblim
+http://i.imgur.com/g6NIm37.jpg`Buneary
+http://i.imgur.com/NXpIvqV.jpg`Lopunny
+http://i.imgur.com/kOOI5E4.jpg`Mega Lopunny
+http://i.imgur.com/WqZ5Mj5.jpg`Mismagius
+http://i.imgur.com/8gtXHdR.jpg`Honchkrow
+http://i.imgur.com/6Gt7453.jpg`Glameow
+http://i.imgur.com/ysFC0Z4.jpg`Purugly
+http://i.imgur.com/8w0MK5l.jpg`Chingling
+http://i.imgur.com/dBtSiou.jpg`Stunky
+http://i.imgur.com/0uzxHbz.jpg`Skuntank
+http://i.imgur.com/SvLhyUV.jpg`Bronzor
+http://i.imgur.com/vgFytzF.jpg`Bronzong
+http://i.imgur.com/MfduOaP.jpg`Bonsly
+http://i.imgur.com/65cgayA.jpg`Mime`Jr.
+http://i.imgur.com/zHwNnnY.jpg`Happiny
+http://i.imgur.com/o4luFk0.jpg`Chatot
+http://i.imgur.com/F5XoJLk.jpg`Spiritomb
+http://i.imgur.com/g0Rqq3v.jpg`Gible
+http://i.imgur.com/BlKJzuf.jpg`Gabite
+http://i.imgur.com/8yGv6m8.jpg`Garchomp
+http://i.imgur.com/QAVi6P4.jpg`Mega Garchomp
+http://i.imgur.com/ixkdFMw.jpg`Munchlax
+http://i.imgur.com/W4otMRb.jpg`Riolu
+http://i.imgur.com/mZgXxOw.jpg`Lucario
+http://i.imgur.com/ZomY4f0.jpg`Mega Lucario
+http://i.imgur.com/HjeacMK.jpg`Hippopotas
+http://i.imgur.com/dDwIipL.jpg`Hippowdon
+http://i.imgur.com/8O2EMpw.jpg`Skorupi
+http://i.imgur.com/KYkSCeB.jpg`Drapion
+http://i.imgur.com/0bXurxC.jpg`Croagunk
+http://i.imgur.com/FjKhK8D.jpg`Toxicroak
+http://i.imgur.com/x4rvmBR.jpg`Carnivine
+http://i.imgur.com/PlOhcIX.jpg`Finneon
+http://i.imgur.com/Wr40JXj.jpg`Lumineon
+http://i.imgur.com/amudNMd.jpg`Mantyke
+http://i.imgur.com/IHoqFu6.jpg`Snover
+http://i.imgur.com/TBSx3sy.jpg`Abomasnow
+http://i.imgur.com/mOKh0ei.jpg`Mega Abomasnow
+http://i.imgur.com/VwBYlhW.jpg`Weavile
+http://i.imgur.com/fvzejW6.jpg`Magnezone
+http://i.imgur.com/tkpr3kl.jpg`Lickilicky
+http://i.imgur.com/inVY5t1.jpg`Rhyperior
+http://i.imgur.com/1cBT3fO.jpg`Tangrowth
+http://i.imgur.com/gFUGPHg.jpg`Electivire
+http://i.imgur.com/YJbMOSu.jpg`Magmortar
+http://i.imgur.com/DZj0bod.jpg`Togekiss
+http://i.imgur.com/4s8H9fa.jpg`Yanmega
+http://i.imgur.com/dtph8xA.jpg`Leafeon
+http://i.imgur.com/a1VQii9.jpg`Glaceon
+http://i.imgur.com/ZY5ccni.jpg`Gliscor
+http://i.imgur.com/TGHUHwf.jpg`Mamoswine
+http://i.imgur.com/iN6GphU.jpg`Porygon-Z
+http://i.imgur.com/9GGRDKn.jpg`Gallade
+http://i.imgur.com/vWQmABp.jpg`Mega Gallade
+http://i.imgur.com/Or98MPO.jpg`Probopass
+http://i.imgur.com/h8ONbM2.jpg`Dusknoir
+http://i.imgur.com/0X7sysY.jpg`Froslass
+http://i.imgur.com/IBTaE6G.jpg`Rotom
+http://i.imgur.com/2fRwrp8.jpg`Heat Rotom
+http://i.imgur.com/ntK2lpS.jpg`Wash Rotom
+http://i.imgur.com/rsMN2MA.jpg`Frost Rotom
+http://i.imgur.com/eHncXVn.jpg`Fan Rotom
+http://i.imgur.com/vZfleJP.jpg`Mow Rotom
+http://i.imgur.com/48iAeDS.jpg`Uxie
+http://i.imgur.com/40zoTS8.jpg`Mesprit
+http://i.imgur.com/8o2wkkq.jpg`Azelf
+http://i.imgur.com/WRenXoY.jpg`Dialga
+http://i.imgur.com/CYCrL08.jpg`Palkia
+http://i.imgur.com/G1yLavH.jpg`Heatran
+http://i.imgur.com/V38YdkE.jpg`Regigigas
+http://i.imgur.com/4AOatXw.jpg`Giratina Origin
+http://i.imgur.com/vspxoDq.jpg`Giratina Altered
+http://i.imgur.com/enqu0el.jpg`Cresselia
+http://i.imgur.com/QR4RD2Y.jpg`Phione
+http://i.imgur.com/z3EN4CR.jpg`Manaphy
+http://i.imgur.com/OIpM7oW.jpg`Darkrai
+http://i.imgur.com/bn3UpR8.jpg`Shaymin Land
+http://i.imgur.com/2hd7T5u.jpg`Shaymin Sky
+http://i.imgur.com/atulPAk.jpg`Arceus
+http://i.imgur.com/2Q4BJSv.jpg`Victini
+http://i.imgur.com/ssiUWQP.jpg`Snivy
+http://i.imgur.com/RhSIDkU.jpg`Servine
+http://i.imgur.com/VNpUIiH.jpg`Serperior
+http://i.imgur.com/oPdhfWU.jpg`Tepig
+http://i.imgur.com/7XyBw0G.jpg`Pignite
+http://i.imgur.com/UhSfn1x.jpg`Emboar
+http://i.imgur.com/8oDQ3XS.jpg`Oshawott
+http://i.imgur.com/rr5LsYh.jpg`Dewott
+http://i.imgur.com/iiNq7qZ.jpg`Samurott
+http://i.imgur.com/lSAdqee.jpg`Patrat
+http://i.imgur.com/cBf3RAU.jpg`Watchog
+http://i.imgur.com/zCYVLIn.jpg`Lillipup
+http://i.imgur.com/eDD7qnS.jpg`Herdier
+http://i.imgur.com/w3NAczB.jpg`Stoutland
+http://i.imgur.com/PcsIbLr.jpg`Purrloin
+http://i.imgur.com/e73abGN.jpg`Liepard
+http://i.imgur.com/g5g6Cf2.jpg`Pansage
+http://i.imgur.com/eEyKXhE.jpg`Simisage
+http://i.imgur.com/XTwDHXz.jpg`Pansear
+http://i.imgur.com/bEXKXfF.jpg`Simisear
+http://i.imgur.com/kS50Cq0.jpg`Panpour
+http://i.imgur.com/KVIMoa4.jpg`Simipour
+http://i.imgur.com/8eyQdEA.jpg`Munna
+http://i.imgur.com/KKdaat0.jpg`Musharna
+http://i.imgur.com/b2eec4a.jpg`Pidove
+http://i.imgur.com/XgiMOaL.jpg`Tranquill
+http://i.imgur.com/oGvpmJe.jpg`Unfezant
+http://i.imgur.com/VtsazKG.jpg`Blitzle
+http://i.imgur.com/AsAmRkE.jpg`Zebstrika
+http://i.imgur.com/B3bi2J1.jpg`Roggenrola
+http://i.imgur.com/eGwy5M0.jpg`Boldore
+http://i.imgur.com/jGHMZzt.jpg`Gigalith
+http://i.imgur.com/Ckz5gIu.jpg`Woobat
+http://i.imgur.com/OXCS8LK.jpg`Swoobat
+http://i.imgur.com/KWGSiMF.jpg`Drilbur
+http://i.imgur.com/M9WKhrm.jpg`Excadrill
+http://i.imgur.com/EQPVV8Z.jpg`Audino
+http://i.imgur.com/Ncu3Y9L.jpg`Mega Audino
+http://i.imgur.com/02aXo5M.jpg`Timburr
+http://i.imgur.com/MemRS7f.jpg`Gurdurr
+http://i.imgur.com/xxOb2gX.jpg`Conkeldurr
+http://i.imgur.com/XZtDThG.jpg`Tympole
+http://i.imgur.com/toHEURY.jpg`Palpitoad
+http://i.imgur.com/fF5uvis.jpg`Seismitoad
+http://i.imgur.com/GbYNzLk.jpg`Throh
+http://i.imgur.com/n16mDPi.jpg`Sawk
+http://i.imgur.com/XKXKLv4.jpg`Sewaddle
+http://i.imgur.com/wXgBiFa.jpg`Swadloon
+http://i.imgur.com/lPczFsz.jpg`Leavanny
+http://i.imgur.com/r0EuuQ4.jpg`Venipede
+http://i.imgur.com/V4tcuCg.jpg`Whirlipede
+http://i.imgur.com/lgBZDR5.jpg`Scolipede
+http://i.imgur.com/oQgqa9a.jpg`Cottonee
+http://i.imgur.com/mkTEawp.jpg`Whimsicott
+http://i.imgur.com/WNT56ig.jpg`Petilil
+http://i.imgur.com/z90x4Zo.jpg`Lilligant
+http://i.imgur.com/9tLSa6I.jpg`Basculin
+http://i.imgur.com/0bTUnIW.jpg`Basculin
+http://i.imgur.com/R1kPNID.jpg`Sandile
+http://i.imgur.com/cibEmA9.jpg`Krokorok
+http://i.imgur.com/Ratx3Nn.jpg`Krookodile
+http://i.imgur.com/XpOP59m.jpg`Darumaka
+http://i.imgur.com/u82uxzo.jpg`Darmanitan
+http://i.imgur.com/x7Z6dLJ.jpg`Maractus
+http://i.imgur.com/Nb6h4pU.jpg`Dwebble
+http://i.imgur.com/Yr6Momy.jpg`Crustle
+http://i.imgur.com/Lh4HIad.jpg`Scraggy
+http://i.imgur.com/hqvEcFl.jpg`Scrafty
+http://i.imgur.com/hVcpcDQ.jpg`Sigilyph
+http://i.imgur.com/tlbubOY.jpg`Yamask
+http://i.imgur.com/rJUhGvk.jpg`Cofagrigus
+http://i.imgur.com/b9Oe8Gv.jpg`Tirtouga
+http://i.imgur.com/oruKWCv.jpg`Carracosta
+http://i.imgur.com/2NERvrM.jpg`Archen
+http://i.imgur.com/Y9WdVn8.jpg`Archeops
+http://i.imgur.com/mvll7rF.jpg`Trubbish
+http://i.imgur.com/gdKOIfO.jpg`Garbodor
+http://i.imgur.com/mOUJ1lW.jpg`Zorua
+http://i.imgur.com/SUEovpZ.jpg`Zoroark
+http://i.imgur.com/jGgb94t.jpg`Minccino
+http://i.imgur.com/Edv041Q.jpg`Cinccino
+http://i.imgur.com/9qqNCAs.jpg`Gothita
+http://i.imgur.com/JXPngWz.jpg`Gothorita
+http://i.imgur.com/mtGfdtD.jpg`Gothitelle
+http://i.imgur.com/QS50Wrw.jpg`Solosis
+http://i.imgur.com/52PVQih.jpg`Duosion
+http://i.imgur.com/877O2CU.jpg`Reuniclus
+http://i.imgur.com/Pc1Xmnl.jpg`Ducklett
+http://i.imgur.com/pn3eqPi.jpg`Swanna
+http://i.imgur.com/WMln18p.jpg`Vanillite
+http://i.imgur.com/SphvNMp.jpg`Vanillish
+http://i.imgur.com/hrRE4pA.jpg`Vanilluxe
+http://i.imgur.com/DHA4Ct4.jpg`Deerling
+http://i.imgur.com/E0fjiCN.jpg`Sawsbuck
+http://i.imgur.com/MTgbPHm.jpg`Sawsbuck
+http://i.imgur.com/B5HiSEg.jpg`Sawsbuck
+http://i.imgur.com/VhUmYl5.jpg`Sawsbuck
+http://i.imgur.com/qyusgtJ.jpg`Emolga
+http://i.imgur.com/HZoaptj.jpg`Karrablast
+http://i.imgur.com/PCfdmVr.jpg`Escavalier
+http://i.imgur.com/HyiYiBD.jpg`Foongus
+http://i.imgur.com/gkCyknE.jpg`Amoonguss
+http://i.imgur.com/743j1OF.jpg`Frillish
+http://i.imgur.com/X3s73tr.jpg`Jellicent
+http://i.imgur.com/1UsDR1A.jpg`Alomomola
+http://i.imgur.com/nm2pRzx.jpg`Joltik
+http://i.imgur.com/Dr9NMbg.jpg`Galvantula
+http://i.imgur.com/KQ9iKUZ.jpg`Ferroseed
+http://i.imgur.com/FIJ137O.jpg`Ferrothorn
+http://i.imgur.com/JqItgIx.jpg`Klink
+http://i.imgur.com/fglg6BH.jpg`Klang
+http://i.imgur.com/d3JkIjI.jpg`Klinklang
+http://i.imgur.com/ueUFPw4.jpg`Tynamo
+http://i.imgur.com/kMggsT2.jpg`Eelektrik
+http://i.imgur.com/CskjfPa.jpg`Eelektross
+http://i.imgur.com/iZwydEx.jpg`Elgyem
+http://i.imgur.com/8VXGgA4.jpg`Beheeyem
+http://i.imgur.com/pIi5rMp.jpg`Litwick
+http://i.imgur.com/zoE4D0i.jpg`Lampent
+http://i.imgur.com/12HVj7Y.jpg`Chandelure
+http://i.imgur.com/9V95q4a.jpg`Axew
+http://i.imgur.com/BeCZjzc.jpg`Fraxure
+http://i.imgur.com/TdP9ajl.jpg`Haxorus
+http://i.imgur.com/58VdwCm.jpg`Cubchoo
+http://i.imgur.com/Z0Rxtbk.jpg`Beartic
+http://i.imgur.com/yoqa6Ep.jpg`Cryogonal
+http://i.imgur.com/QQMub3e.jpg`Shelmet
+http://i.imgur.com/73fXuiV.jpg`Accelgor
+http://i.imgur.com/BAFDQ0w.jpg`Stunfisk
+http://i.imgur.com/BZBv3Xd.jpg`Mienfoo
+http://i.imgur.com/anaxQR7.jpg`Mienshao
+http://i.imgur.com/1sepsfp.jpg`Druddigon
+http://i.imgur.com/fAaEoIV.jpg`Golett
+http://i.imgur.com/eugACee.jpg`Golurk
+http://i.imgur.com/aP1yZTx.jpg`Pawniard
+http://i.imgur.com/U2DD4gL.jpg`Bisharp
+http://i.imgur.com/9K3TFvx.jpg`Bouffalant
+http://i.imgur.com/QlAT7UG.jpg`Rufflet
+http://i.imgur.com/vo0FBhd.jpg`Braviary
+http://i.imgur.com/n04RJd8.jpg`Vullaby
+http://i.imgur.com/QsJKuvi.jpg`Mandibuzz
+http://i.imgur.com/rJv37Mo.jpg`Heatmor
+http://i.imgur.com/aQ4P7xA.jpg`Durant
+http://i.imgur.com/72jRzoa.jpg`Deino
+http://i.imgur.com/7Q4sLv6.jpg`Zweilous
+http://i.imgur.com/uBidDkW.jpg`Hydreigon
+http://i.imgur.com/Cf4uaIV.jpg`Larvesta
+http://i.imgur.com/YZ4ZIwl.jpg`Volcarona
+http://i.imgur.com/blsR6bk.jpg`Cobalion
+http://i.imgur.com/odjZyDe.jpg`Terrakion
+http://i.imgur.com/43izQwW.jpg`Virizion
+http://i.imgur.com/cqzsDvl.jpg`Tornadus Incarnate
+http://i.imgur.com/t4Kv8Pp.jpg`Tornadus Therian
+http://i.imgur.com/EZis34j.jpg`Thundurus Incarnate
+http://i.imgur.com/KyDnfzS.jpg`Thundurus Therian
+http://i.imgur.com/f8DVbFy.jpg`Reshiram
+http://i.imgur.com/doANON9.jpg`Zekrom
+http://i.imgur.com/Yy6d1Ot.jpg`Landorus Incarnate
+http://i.imgur.com/tA9epxY.jpg`Landorus Therian
+http://i.imgur.com/ORC0ycw.jpg`Kyurem
+http://i.imgur.com/NdCCSMa.jpg`Black Kyurem
+http://i.imgur.com/QQRn3xs.jpg`White Kyurem
+http://i.imgur.com/QWTfpv3.jpg`Keldeo Ordinary
+http://i.imgur.com/yhYTiST.jpg`Keldeo Resolute
+http://i.imgur.com/iFYHDYU.jpg`Meloetta Aria
+http://i.imgur.com/c8QBJHT.jpg`Meloetta Pirouette
+http://i.imgur.com/bO5l97s.jpg`Genesect
+http://i.imgur.com/CdvwWXE.jpg`Chespin
+http://i.imgur.com/YFh2MkF.jpg`Quilladin
+http://i.imgur.com/lNKyMOa.jpg`Chesnaught
+http://i.imgur.com/N3Q3xT2.jpg`Fennekin
+http://i.imgur.com/nkeElsd.jpg`Braixen
+http://i.imgur.com/8lc9TL6.jpg`Delphox
+http://i.imgur.com/t17DoCf.jpg`Froakie
+http://i.imgur.com/39VQVHO.jpg`Frogadier
+http://i.imgur.com/6Pwz64x.jpg`Greninja
+http://i.imgur.com/XxKxKD2.jpg`Bunnelby
+http://i.imgur.com/0iKkudd.jpg`Diggersby
+http://i.imgur.com/XGU9JAj.jpg`Fletchling
+http://i.imgur.com/VJO75PX.jpg`Fletchinder
+http://i.imgur.com/fCucb60.jpg`Talonflame
+http://i.imgur.com/nhX91hM.jpg`Scatterbug
+http://i.imgur.com/KGVMrTY.jpg`Spewpa
+http://i.imgur.com/VevAssW.jpg`Vivillon
+http://i.imgur.com/ZkZshJS.jpg`Litleo
+http://i.imgur.com/qPUzKdo.jpg`Pyroar
+http://i.imgur.com/3ToiYNh.jpg`Flabébé
+http://i.imgur.com/lD0afOn.jpg`Floette
+http://i.imgur.com/UI5Uaz8.jpg`Florges
+http://i.imgur.com/gpqCCyI.jpg`Skiddo
+http://i.imgur.com/XMQOWkY.jpg`Gogoat
+http://i.imgur.com/v0uEUel.jpg`Pancham
+http://i.imgur.com/UkNxixN.jpg`Pangoro
+http://i.imgur.com/nqZ46we.jpg`Furfrou
+http://i.imgur.com/OaKTqBc.jpg`Espurr
+http://i.imgur.com/v6TnuqR.jpg`Meowstic
+http://i.imgur.com/y9UrszU.jpg`Honedge
+http://i.imgur.com/utnaW5g.jpg`Doublade
+http://i.imgur.com/LE8Oq8e.jpg`Aegislash Shield
+http://i.imgur.com/HrfID0o.jpg`Aegislash Blade
+http://i.imgur.com/3F6AA8h.jpg`Spritzee
+http://i.imgur.com/kwUQ86M.jpg`Aromatisse
+http://i.imgur.com/7U8uuxw.jpg`Swirlix
+http://i.imgur.com/dcqoYBY.jpg`Slurpuff
+http://i.imgur.com/scUYMij.jpg`Inkay
+http://i.imgur.com/DiRgLG2.jpg`Malamar
+http://i.imgur.com/OHX5I7v.jpg`Binacle
+http://i.imgur.com/Mu7YDY5.jpg`Barbaracle
+http://i.imgur.com/Jbae8W3.jpg`Skrelp
+http://i.imgur.com/07437t1.jpg`Dragalge
+http://i.imgur.com/vIoMqdQ.jpg`Clauncher
+http://i.imgur.com/fjdJn1Z.jpg`Clawitzer
+http://i.imgur.com/fEIs56A.jpg`Helioptile
+http://i.imgur.com/tXpnCo1.jpg`Heliolisk
+http://i.imgur.com/pNOZEer.jpg`Tyrunt
+http://i.imgur.com/AV3KdAn.jpg`Tyrantrum
+http://i.imgur.com/nNQrI9r.jpg`Amaura
+http://i.imgur.com/Sqar05J.jpg`Aurorus
+http://i.imgur.com/6kIKWsK.jpg`Sylveon
+http://i.imgur.com/tceZ19c.jpg`Hawlucha
+http://i.imgur.com/xySRV5W.jpg`Dedenne
+http://i.imgur.com/EMclKGM.jpg`Carbink
+http://i.imgur.com/DYLtieb.jpg`Goomy
+http://i.imgur.com/CSBOePU.jpg`Sliggoo
+http://i.imgur.com/jK9ynv3.jpg`Goodra
+http://i.imgur.com/c37jeUE.jpg`Klefki
+http://i.imgur.com/ocKNyBU.jpg`Phantump
+http://i.imgur.com/mkPLwRZ.jpg`Trevenant
+http://i.imgur.com/Il74Zxu.jpg`Pumpkaboo
+http://i.imgur.com/D0DCDky.jpg`Gourgeist
+http://i.imgur.com/YprQqNQ.jpg`Bergmite
+http://i.imgur.com/qJHnLHq.jpg`Avalugg
+http://i.imgur.com/Xma5Pys.jpg`Noibat
+http://i.imgur.com/OaWoiF8.jpg`Noivern
+http://i.imgur.com/p0a4tOM.jpg`Xerneas
+http://i.imgur.com/LcWUa0B.jpg`Yveltal
+http://i.imgur.com/XIxvXt2.jpg`Zygarde 50%
+http://i.imgur.com/AnHEUp8.jpg`Zygarde 10%
+http://i.imgur.com/sUASwWy.jpg`Zygarde Complete
+http://i.imgur.com/1UleeRN.jpg`Diancie
+http://i.imgur.com/NagPVG1.jpg`Mega Diancie
+http://i.imgur.com/bdtm06y.jpg`Hoopa Confined
+http://i.imgur.com/AwJBkWk.jpg`Hoopa Unbound
+http://i.imgur.com/WvC7LsD.jpg`Volcanion
+http://i.imgur.com/RppXk14.jpg`Rowlet
+http://i.imgur.com/B2bmydT.jpg`Dartrix
+http://i.imgur.com/bnbLCcL.jpg`Decidueye
+http://i.imgur.com/SfkhLAF.jpg`Litten
+http://i.imgur.com/dK5owWG.jpg`Torracat
+http://i.imgur.com/ahmU80c.jpg`Incineroar
+http://i.imgur.com/uXne2tg.jpg`Popplio
+http://i.imgur.com/r9yFpdC.jpg`Brionne
+http://i.imgur.com/MiIKYIN.jpg`Primarina
+http://i.imgur.com/FmwfsmV.jpg`Pikipek
+http://i.imgur.com/F5UyKLh.jpg`Trumbeak
+http://i.imgur.com/SAiD7S0.jpg`Toucannon
+http://i.imgur.com/Mzp1FqW.jpg`Yungoos
+http://i.imgur.com/2oODzz9.jpg`Gumshoos
+http://i.imgur.com/OceIscP.jpg`Grubbin
+http://i.imgur.com/VmXlvaV.jpg`Charjabug
+http://i.imgur.com/7TL00lS.jpg`Vikavolt
+http://i.imgur.com/LEkBgVw.jpg`Crabrawler
+http://i.imgur.com/J5EunSp.jpg`Crabominable
+http://i.imgur.com/dUmQt0f.jpg`Oricorio
+http://i.imgur.com/RqgR22u.jpg`Oricorio
+http://i.imgur.com/Cgs6E9r.jpg`Oricorio
+http://i.imgur.com/Jcj37kp.jpg`Oricorio
+http://i.imgur.com/gr46H8O.jpg`Cutiefly
+http://i.imgur.com/uVUcZBl.jpg`Ribombee
+http://i.imgur.com/UHrTPqJ.jpg`Rockruff
+http://i.imgur.com/0RbRRA1.jpg`Lycanroc Midday
+http://i.imgur.com/96yLo6l.jpg`Lycanroc Midnight
+http://i.imgur.com/5Bhg16Z.jpg`Wishiwashi School
+http://i.imgur.com/m7978lm.jpg`Wishiwashi Solo
+http://i.imgur.com/QpF3Om4.jpg`Mareanie
+http://i.imgur.com/CFhT2hl.jpg`Toxapex
+http://i.imgur.com/Jkw6DYA.jpg`Mudbray
+http://i.imgur.com/MH4lC1A.jpg`Mudsdale
+http://i.imgur.com/3z9CoVc.jpg`Dewpider
+http://i.imgur.com/PYYjTdK.jpg`Araquanid
+http://i.imgur.com/ZbHH117.jpg`Fomantis
+http://i.imgur.com/EwlsSpU.jpg`Lurantis
+http://i.imgur.com/gjGp26z.jpg`Morelull
+http://i.imgur.com/YngPb7F.jpg`Shiinotic
+http://i.imgur.com/PndkQF0.jpg`Salandit
+http://i.imgur.com/5xgr90J.jpg`Salazzle
+http://i.imgur.com/V01t1pm.jpg`Stufful
+http://i.imgur.com/3D13vEi.jpg`Bewear
+http://i.imgur.com/5CG7grx.jpg`Bounsweet
+http://i.imgur.com/da3Pkje.jpg`Steenee
+http://i.imgur.com/33JUpTX.jpg`Tsareena
+http://i.imgur.com/tZuheoX.jpg`Comfey
+http://i.imgur.com/vg0fk2c.jpg`Oranguru
+http://i.imgur.com/71DWLtn.jpg`Passimian
+http://i.imgur.com/PT12Fgx.jpg`Wimpod
+http://i.imgur.com/ft6Lm2m.jpg`Golisopod
+http://i.imgur.com/CSiIyUx.jpg`Sandygast
+http://i.imgur.com/u5V1EuB.jpg`Palossand
+http://i.imgur.com/jfZG4os.jpg`Pyukumuku
+http://i.imgur.com/AIhY7Cn.jpg`Type: Null
+http://i.imgur.com/vQdLW3s.jpg`Silvally
+http://i.imgur.com/sxiFLcO.jpg`Minior
+http://i.imgur.com/RNTQTO9.jpg`Minior
+http://i.imgur.com/TpDPdcD.jpg`Komala
+http://i.imgur.com/apnQZ9k.jpg`Turtonator
+http://i.imgur.com/UR3XOqm.jpg`Togedemaru
+http://i.imgur.com/Zi9YElr.jpg`Mimikyu
+http://i.imgur.com/xQg25os.jpg`Bruxish
+http://i.imgur.com/PWMmthR.jpg`Drampa
+http://i.imgur.com/oKvMriL.jpg`Dhelmise
+http://i.imgur.com/QFHEBAD.jpg`Jangmo-o
+http://i.imgur.com/YfLXIh2.jpg`Hakamo-o
+http://i.imgur.com/pARfjnm.jpg`Kommo-o
+http://i.imgur.com/cC8h7wn.jpg`Tapu Koko
+http://i.imgur.com/esepEgA.jpg`Tapu Lele
+http://i.imgur.com/bbsG8SP.jpg`Tapu Bulu
+http://i.imgur.com/dLwuDOt.jpg`Tapu Fini
+http://i.imgur.com/6r674Cq.jpg`Cosmog
+http://i.imgur.com/2Qvjsos.jpg`Cosmoem
+http://i.imgur.com/Xjbw0DV.jpg`Solgaleo
+http://i.imgur.com/DYfh8AY.jpg`Lunala
+http://i.imgur.com/S1HTUVh.jpg`Nihilego
+http://i.imgur.com/LxuNhui.jpg`Buzzwole
+http://i.imgur.com/Dw71KtJ.jpg`Pheromosa
+http://i.imgur.com/akw5lwg.jpg`Xurkitree
+http://i.imgur.com/DWvKzzY.jpg`Celesteela
+http://i.imgur.com/tiVzY9g.jpg`Kartana
+http://i.imgur.com/rmEwzmI.jpg`Guzzlord
+http://i.imgur.com/oJQlw6W.jpg`Necrozma
+http://i.imgur.com/7l5Bco6.jpg`Magearna
+http://i.imgur.com/rGBZSxr.jpg`Marshadow


### PR DESCRIPTION
Silhouette pictures of Gens II~VII Pokémon are added, including all the mega evolutions and alternate forms. Gen I mega evolutions are also added. I included the form name without using the words "form" "forme" etc (e.g. "Zygarde Complete" rather than "Zygarde Complete Forme", "Shaymin Sky" rather than "Shaymin Sky Forme", and so forth). So the code will have to be switched to the "contains" mode so that any answers with "form/forme" at the end get accepted by the bot.