### PR TITLE
Fix: show the real items id on `~>market`

### DIFF
--- a/src/main/java/net/kodehawa/mantarobot/commands/CurrencyCmds.java
+++ b/src/main/java/net/kodehawa/mantarobot/commands/CurrencyCmds.java
@@ -268,7 +268,7 @@ public class CurrencyCmds {
                         String sellValue = item.isSellable() ? String.format("$%d", (int) Math.floor(item.getValue
                                 () * 0.9)) : "N/A";
 
-                        items.append(String.format("**%02d.-** %s *%s*    ", atomicInteger.incrementAndGet(), item.getEmoji(), item.getName())).append("\n");
+                        items.append(String.format("**%02d.-** %s *%s*    ", atomicInteger.getAndIncrement(), item.getEmoji(), item.getName())).append("\n");
                         prices.append(String.format("%s **%s, %s**", "\uD83D\uDCB2", buyValue, sellValue)).append("\n");
                     }
                 });


### PR DESCRIPTION
I discovered an issue with Mantaro: the items ids are starting from 0 but when we are running `~>market`, the bot counts and shows them from 1 to n.

![Issue example](https://i.imgur.com/K16phCG.jpg)