### PR TITLE
Fix an issue in Itemtransfer

### DIFF
--- a/src/main/java/net/kodehawa/mantarobot/commands/CurrencyCmds.java
+++ b/src/main/java/net/kodehawa/mantarobot/commands/CurrencyCmds.java
@@ -362,7 +362,7 @@ public class CurrencyCmds {
                                     return;
                                 }
 
-                                if(giveToPlayer.getInventory().asMap().getOrDefault(item, new ItemStack(item, 0)).getAmount() + amount >= 5000) {
+                                if(giveToPlayer.getInventory().asMap().getOrDefault(item, new ItemStack(item, 0)).getAmount() + amount > 5000) {
                                     event.getChannel().sendMessage(EmoteReference.ERROR + "Don't do that").queue();
                                     return;
                                 }


### PR DESCRIPTION
Itemtransfer tells you "Don't do that" (only on custom amounts i.e `itemtransfer <@mention> <item> <amount>` and not0 `itemtransfer <@mention> <item>) that you cannot give someone more than 4999 items. 
If i didnt fully miss understand the code this fixes it since you check for getAmount + amount >= 5000 which if someone attempts to get another person to exactly 5000 would trigger cuz it equals 5000.