### PR TITLE
Adding .DS_Store into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ quotes.json
 
 #RethinkDB
 /db/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Adding .DS_Store into .gitignore to prevent unnecessary .DS_Store file being add into commit, also be more convenience when adding git changes for macOS user.

macOS user can't use `git add .` because it will also commit unnecessary .DS_Store file, it's inconvenient for macOS user.

And also a PR to 4.9: https://github.com/Mantaro/MantaroBot/pull/123