### PR TITLE
Fix race condition due to non-threadsafe use of reflections lib

### DIFF
--- a/src/main/java/net/kodehawa/mantarobot/core/MantaroCore.java
+++ b/src/main/java/net/kodehawa/mantarobot/core/MantaroCore.java
@@ -136,6 +136,7 @@ public class MantaroCore {
             throw new IllegalArgumentException("Cannot look for options if you don't specify where!");
 
         Future<Set<Class<?>>> commands = lookForAnnotatedOn(commandsPackage, Module.class);
+        Set<Class<?>> classes = commands.get(); // reflections lib not threadsafe
         Future<Set<Class<?>>> options = lookForAnnotatedOn(optsPackage, Option.class);
 
         if(single) {
@@ -145,7 +146,7 @@ public class MantaroCore {
         }
 
         shardEventBus = new EventBus();
-        for(Class<?> aClass : commands.get()) {
+        for(Class<?> aClass : classes) {
             try {
                 shardEventBus.register(aClass.newInstance());
             } catch(Exception e) {


### PR DESCRIPTION
sorry for shit quality fix but you asked for it :D 
wrote this three weeks ago

cant test something different cause everything is exploding when i try to run it and I don't have time to sort it out rn

the root issue is probably instantiating the reflections lib more than once (see `MantaroCode#lookForAnnotatedOn`) and could maybe be solved with a singleton of it