### PR TITLE
resume as an alias for pause | de_DE

### DIFF
--- a/src/main/resources/assets/languages/de_DE.json
+++ b/src/main/resources/assets/languages/de_DE.json
@@ -188,8 +188,8 @@
       "header": "Spiele derzeit"
     },
     "pause": {
-      "paused": "Wiedergabe pausiert.",
-      "unpaused": "Wiedergabe wird fortgesetzt."
+      "paused": "Wiedergabe pausiert. *(Wiedergabe wurde zuvor fortgesetzt)*",
+      "unpaused": "Wiedergabe wird fortgesetzt. *(Wiedergabe wurde zuvor pausiert)*"
     },
     "rewind": {
       "negative": "%1$sNur positive Ganzzahlen",


### PR DESCRIPTION
Added changes from https://github.com/Mantaro/MantaroBot/commit/4d2acce4663216d681a617e229a73d6df425f69f