### PR TITLE
Stop Mantaro from throwing an error on boot if no Weeb API key is set

### DIFF
--- a/src/main/java/net/kodehawa/mantarobot/commands/ActionCmds.java
+++ b/src/main/java/net/kodehawa/mantarobot/commands/ActionCmds.java
@@ -17,18 +17,25 @@
 
 package net.kodehawa.mantarobot.commands;
 
+import java.awt.Color;
+import java.util.List;
+
 import com.google.common.eventbus.Subscribe;
+
+import org.slf4j.LoggerFactory;
+
 import net.kodehawa.mantarobot.commands.action.ImageActionCmd;
 import net.kodehawa.mantarobot.commands.action.ImageCmd;
 import net.kodehawa.mantarobot.commands.action.TextActionCmd;
 import net.kodehawa.mantarobot.core.CommandRegistry;
+import net.kodehawa.mantarobot.core.MantaroCore;
 import net.kodehawa.mantarobot.core.modules.Module;
+import net.kodehawa.mantarobot.data.MantaroData;
 import net.kodehawa.mantarobot.utils.commands.EmoteReference;
 import net.kodehawa.mantarobot.utils.data.DataManager;
 import net.kodehawa.mantarobot.utils.data.SimpleFileDataManager;
-
-import java.awt.*;
-import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Module
 @SuppressWarnings("unused")
@@ -40,88 +47,10 @@ public class ActionCmds {
     private final DataManager<List<String>> NUZZLE = new SimpleFileDataManager("assets/mantaro/texts/nuzzle.txt");
     private final DataManager<List<String>> TSUNDERE = new SimpleFileDataManager("assets/mantaro/texts/tsundere.txt");
 
+    private static final Logger log = LoggerFactory.getLogger(CustomCmds.class);
+
     @Subscribe
     public void register(CommandRegistry cr) {
-        //pat();
-        cr.register("pat", new ImageActionCmd(
-                "Pat", "Pats the specified user.", EmoteReference.TALKING,
-                "commands.action.pat", "pat", "commands.action.lonely.pat", "commands.action.self.pat"
-        ));
-
-        //hug();
-        cr.register("hug", new ImageActionCmd(
-                "Hug", "Hugs the specified user.", EmoteReference.TALKING,
-                "commands.action.hug", "hug", "commands.action.lonely.hug", "commands.action.self.hug"
-        ));
-
-        //kiss();
-        cr.register("kiss", new ImageActionCmd(
-                "Kiss", "Kisses the specified user.", EmoteReference.TALKING,
-                "commands.action.kiss", "kiss", "commands.action.lonely.kiss", "commands.action.self.kiss"
-        ));
-
-        //poke();
-        cr.register("poke", new ImageActionCmd(
-                "Poke", "Pokes the specified user.", EmoteReference.TALKING,
-                "commands.action.poke", "poke", "commands.action.lonely.poke", "commands.action.self.poke"
-        ));
-
-        //slap();
-        cr.register("slap", new ImageActionCmd(
-                "Slap", "Slaps the specified user ;).", EmoteReference.TALKING,
-                "commands.action.slap", "slap", "commands.action.lonely.slap", "commands.action.self.slap"
-        ));
-
-        //bite();
-        cr.register("bite", new ImageActionCmd(
-                "Bite", "Bites the specified user.", EmoteReference.TALKING,
-                "commands.action.bite", "bite", "commands.action.lonely.bite", "commands.action.self.bite"
-        ));
-
-        //tickle();
-        cr.register("tickle", new ImageActionCmd(
-                "Tickle", "Tickles the specified user.", EmoteReference.JOY,
-                "commands.action.tickle", "tickle", "commands.action.lonely.tickle", "commands.action.self.tickle"
-        ));
-
-        //highfive();
-        cr.register("highfive", new ImageActionCmd(
-                "Highfive", "Highfives with the specified user.", EmoteReference.TALKING,
-                "commands.action.highfive", "highfive", "commands.action.lonely.highfive", "commands.action.self.highfive", true
-        ));
-
-        //pout();
-        cr.register("pout", new ImageActionCmd(
-                "Pout", "Pouts at the specified user.", EmoteReference.TALKING,
-                "commands.action.pout", "pout", "commands.action.lonely.pout", "commands.action.self.pout", true
-        ));
-
-        //lick();
-        cr.register("lick", new ImageActionCmd(
-                "lick", "Licks the specified user.", EmoteReference.TALKING,
-                "commands.action.lick", "lick", "commands.action.lonely.lick", "commands.action.self.lick"
-        ));
-
-        //teehee();
-        cr.register("teehee", new ImageActionCmd("Teehee", "Teehee~", EmoteReference.EYES,
-                "commands.action.teehee", "teehee", "commands.action.lonely.teehee", "commands.action.self.teehee", true));
-
-        //smile();
-        cr.register("smile", new ImageActionCmd("Smile", "Smiles at someone", EmoteReference.TALKING,
-                "commands.action.smile", "smile", "commands.action.lonely.smile", "commands.action.self.smile", true));
-
-        //stare();
-        cr.register("stare", new ImageActionCmd("Stare", "Stares at someone", EmoteReference.EYES,
-                "commands.action.stare", "stare", "commands.action.lonely.stare", "commands.action.self.stare", true));
-
-        //holdhands();
-        cr.register("holdhands", new ImageActionCmd("Hold Hands", "Hold someone's hands", EmoteReference.HEART,
-                "commands.action.holdhands", "handholding", "commands.action.lonely.holdhands", "commands.action.self.holdhands", true));
-
-        //cuddle();
-        cr.register("cuddle", new ImageActionCmd("Cuddle", "Cuddles someone", EmoteReference.HEART,
-                "commands.action.cuddle", "cuddle", "commands.action.lonely.cuddle", "commands.action.self.cuddle"));
-
         //tsundere();
         cr.register("tsundere", new TextActionCmd("Tsundere Command", "Y-You baka!",
                 Color.PINK, EmoteReference.MEGA + "%s", TSUNDERE.get()
@@ -137,18 +66,102 @@ public class ActionCmds {
                 "commands.action.bloodsuck", BLOODSUCK.get(), "commands.action.lonely.bloodsuck", "commands.action.self.bloodsuck", true)
         );
 
-        //lewd();
-        cr.register("lewd", new ImageCmd("Lewd", "T-Too lewd!", "lewd", "lewd", "commands.action.lewd"));
-
         //meow();
         cr.register("meow", new ImageCmd("Meow", "Meows at the specified user.", "meow", MEOW.get(), "commands.action.meow"));
         cr.registerAlias("meow", "mew");
 
-        //nom();
-        cr.register("nom", new ImageCmd("Nom", "*nom nom*", "nom", "nom", "commands.action.nom"));
+        if (MantaroData.config().get().hasWeebapiKey()) {
+                //pat();
+                cr.register("pat", new ImageActionCmd(
+                        "Pat", "Pats the specified user.", EmoteReference.TALKING,
+                        "commands.action.pat", "pat", "commands.action.lonely.pat", "commands.action.self.pat"
+                ));
 
-        //facedesk();
-        cr.register("facedesk", new ImageCmd("Facedesk", "When it's just too much to handle.", "facedesk", "banghead",
-                "commands.action.facedesk", true));
+                //hug();
+                cr.register("hug", new ImageActionCmd(
+                        "Hug", "Hugs the specified user.", EmoteReference.TALKING,
+                        "commands.action.hug", "hug", "commands.action.lonely.hug", "commands.action.self.hug"
+                ));
+
+                //kiss();
+                cr.register("kiss", new ImageActionCmd(
+                        "Kiss", "Kisses the specified user.", EmoteReference.TALKING,
+                        "commands.action.kiss", "kiss", "commands.action.lonely.kiss", "commands.action.self.kiss"
+                ));
+
+                //poke();
+                cr.register("poke", new ImageActionCmd(
+                        "Poke", "Pokes the specified user.", EmoteReference.TALKING,
+                        "commands.action.poke", "poke", "commands.action.lonely.poke", "commands.action.self.poke"
+                ));
+
+                //slap();
+                cr.register("slap", new ImageActionCmd(
+                        "Slap", "Slaps the specified user ;).", EmoteReference.TALKING,
+                        "commands.action.slap", "slap", "commands.action.lonely.slap", "commands.action.self.slap"
+                ));
+
+                //bite();
+                cr.register("bite", new ImageActionCmd(
+                        "Bite", "Bites the specified user.", EmoteReference.TALKING,
+                        "commands.action.bite", "bite", "commands.action.lonely.bite", "commands.action.self.bite"
+                ));
+
+                //tickle();
+                cr.register("tickle", new ImageActionCmd(
+                        "Tickle", "Tickles the specified user.", EmoteReference.JOY,
+                        "commands.action.tickle", "tickle", "commands.action.lonely.tickle", "commands.action.self.tickle"
+                ));
+
+                //highfive();
+                cr.register("highfive", new ImageActionCmd(
+                        "Highfive", "Highfives with the specified user.", EmoteReference.TALKING,
+                        "commands.action.highfive", "highfive", "commands.action.lonely.highfive", "commands.action.self.highfive", true
+                ));
+
+                //pout();
+                cr.register("pout", new ImageActionCmd(
+                        "Pout", "Pouts at the specified user.", EmoteReference.TALKING,
+                        "commands.action.pout", "pout", "commands.action.lonely.pout", "commands.action.self.pout", true
+                ));
+
+                //lick();
+                cr.register("lick", new ImageActionCmd(
+                        "lick", "Licks the specified user.", EmoteReference.TALKING,
+                        "commands.action.lick", "lick", "commands.action.lonely.lick", "commands.action.self.lick"
+                ));
+
+                //teehee();
+                cr.register("teehee", new ImageActionCmd("Teehee", "Teehee~", EmoteReference.EYES,
+                        "commands.action.teehee", "teehee", "commands.action.lonely.teehee", "commands.action.self.teehee", true));
+
+                //smile();
+                cr.register("smile", new ImageActionCmd("Smile", "Smiles at someone", EmoteReference.TALKING,
+                        "commands.action.smile", "smile", "commands.action.lonely.smile", "commands.action.self.smile", true));
+
+                //stare();
+                cr.register("stare", new ImageActionCmd("Stare", "Stares at someone", EmoteReference.EYES,
+                        "commands.action.stare", "stare", "commands.action.lonely.stare", "commands.action.self.stare", true));
+
+                //holdhands();
+                cr.register("holdhands", new ImageActionCmd("Hold Hands", "Hold someone's hands", EmoteReference.HEART,
+                        "commands.action.holdhands", "handholding", "commands.action.lonely.holdhands", "commands.action.self.holdhands", true));
+
+                //cuddle();
+                cr.register("cuddle", new ImageActionCmd("Cuddle", "Cuddles someone", EmoteReference.HEART,
+                        "commands.action.cuddle", "cuddle", "commands.action.lonely.cuddle", "commands.action.self.cuddle"));
+
+                //lewd();
+                cr.register("lewd", new ImageCmd("Lewd", "T-Too lewd!", "lewd", "lewd", "commands.action.lewd"));
+
+                //nom();
+                cr.register("nom", new ImageCmd("Nom", "*nom nom*", "nom", "nom", "commands.action.nom"));
+
+                //facedesk();
+                cr.register("facedesk", new ImageCmd("Facedesk", "When it's just too much to handle.", "facedesk", "banghead",
+                        "commands.action.facedesk", true));
+        } else {
+                log.warn("weeb api key not set in config, some action commands are disabled");
+        }
     }
 }

--- a/src/main/java/net/kodehawa/mantarobot/data/Config.java
+++ b/src/main/java/net/kodehawa/mantarobot/data/Config.java
@@ -237,6 +237,10 @@ public class Config {
         this.spambotUrl = spambotUrl;
     }
 
+    public boolean hasWeebapiKey() {
+        return this.weebapiKey != null;
+    }
+
     public String getWeebapiKey() {
         return this.weebapiKey;
     }


### PR DESCRIPTION
If "weebapiKey" was set to null in the config, the bot would crash as it requests and parses some JSON from Weeb API but the API returned an error instead.

I didn't read through the code too much to find a better way to do this. If there is let me know.