### PR TITLE
Config for Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General Support
+    url: https://support.mantaro.site
+    about: Please join our official support server for general questions. You will get your answer there much quicker.


### PR DESCRIPTION
- Disable blank issues, as we have good enough templates
- Allow people to easily see we have a support server for quick answers