### PR TITLE
locale/en_us/pear: a pear tree

### DIFF
--- a/src/main/resources/assets/languages/en_US.json
+++ b/src/main/resources/assets/languages/en_US.json
@@ -2418,7 +2418,7 @@
       "hellfire_rod": "Way too OP rod (too much durability, find out ;)).",
       "leaves": "A slow drop from a tree you tried to chop.",
       "apple": "You happened to chop an apple tree and the apple fell on your head. Ouch.",
-      "pear": "You happened to chop an pear tree and the pear fell on your head. Ouch.",
+      "pear": "You happened to chop a pear tree and the pear fell on your head. Ouch.",
       "cherry_blossom": "A very slow drop from a cherry tree. Lovely, huh?",
       "rock": "A rock. Yep. It's very hard, isn't it?",
       "broken_moon_pick": "A moon pick that broke while mining. Still salvageable.",


### PR DESCRIPTION
The choice of article used is based on the sound of the first letter of the word. Many confuse this to be the ortographic representation of the letter! Or so [this website][src] says. If the first letter makes the sound of a vowel, then you're supposed to use the letters "an". Otherwise, if it's a consonant sound, you use the letter "a".

For example, you would say "a cat" or "a big apple", or "an apricot" or "an egg". Of course, this being English, there are exceptions: "a honest error" doesn't make sense, but "an honest error" does. Similarly, "a unicorn" should be "an" because it makes the sound of the letter "y", but because English has as much thought and design put into it as JavaScript's initial design it doesn't work.

Anyway, it should be "a pear tree" not "an pear tree".

[src]: https://owl.purdue.edu/owl/general_writing/grammar/articles_a_versus_an.html